### PR TITLE
feat(api): keychain session JWT + deposit/history fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7070,10 +7070,11 @@ app.get('/confirmAFITSEBulk', async function(req,res){
 	//console.log(config.steem_engine_trans_acct_his_lrg);
 	//connect with our service to confirm AFIT received to proper wallet
 	try{
-		let se_connector = await fetch(url);
+		//15s timeout so an unreachable/slow history node fails fast instead of hanging the request
+		let se_connector = await fetch(url, { signal: AbortSignal.timeout(15000) });
 		let trx_entries = await se_connector.json();
-		
-		
+
+
 		//console.log(trx_entries);
 		trx_entries.forEach( async function(entry){
 			console.log(entry);
@@ -7144,9 +7145,15 @@ app.get('/confirmAFITSEBulk', async function(req,res){
 		
 		res.write(JSON.stringify({'status': 'done updating AFIT SE moves'}));
 		res.end();
-		
+
 	}catch(err){
+		//respond on failure (history fetch/parse error) instead of leaving the request hanging
 		console.log(err);
+		if (!res.headersSent){
+			res.status(500).send({'error': 'confirmAFITSEBulk failed', 'detail': String(err && err.message || err)});
+		} else {
+			try { res.end(); } catch(e) {}
+		}
 	}
 })
 

--- a/app.js
+++ b/app.js
@@ -2236,6 +2236,63 @@ app.post('/loginKeychain/', loginRateLimit, async function (req, res) {
 	}
 });
 
+/* second phase of keychain login: verify the decrypted challenge and issue a session JWT.
+   /loginKeychain hands the client an encrypted-memo challenge; the client decrypts it via
+   Hive Keychain (proving it holds the private posting key) and posts the result back here.
+   Keychain logins store no posting key, so this issues a longer-lived token used purely for
+   authenticating checkHdrs API calls (e.g. setUserFundsPass). */
+app.post('/loginKeychainVerify', loginRateLimit, async function (req, res) {
+	try {
+		const username = req.body.username;
+		const decrypted = req.body.decrypted;
+		let bchain = req.body.bchain ? req.body.bchain : 'HIVE';
+
+		if (!username || username.length >= 20 || username.length <= 3 || !decrypted) {
+			return res.send({ success: false, message: 'Authentication failed! Please check the request' });
+		}
+
+		// do not allow login for deleted accounts
+		let deleted = await db.collection('deleted_accounts').findOne({ user: username });
+		if (deleted) {
+			return res.send({ success: false, message: 'error' });
+		}
+
+		// recompute the challenge for this account's posting public key
+		let account = await utils.getAccountData(username, bchain);
+		let pubKey = account[bchain].posting.key_auths[0][0];
+		let expected = encrypt(username + pubKey);
+
+		// the client returns the keychain-decrypted memo; normalize any leading '#'
+		let provided = String(decrypted).trim().replace(/^#/, '');
+		if (provided !== expected) {
+			return res.send({ success: false, message: 'Keychain verification failed' });
+		}
+
+		// proof valid -> issue a session token (no posting key is stored for keychain logins)
+		let token = jwt.sign({ username: username }, config.secret, { expiresIn: '30d' });
+
+		let db_col = db.collection('user_login_token');
+		// preserve any existing record fields (e.g. a previously stored ppkey) and just refresh the token
+		let user_tkn = await db_col.findOne({ user: username });
+		if (!user_tkn) {
+			user_tkn = {};
+		}
+		user_tkn.user = username;
+		user_tkn.token = token;
+		user_tkn.lastlogin = new Date();
+		user_tkn.loginsrc = 'keychain';
+
+		await db_col.replaceOne({ user: username }, user_tkn, { upsert: true });
+
+		// return both `userdata` (used by LoginModal) and the chain-keyed account
+		// (spread, so callers relying on e.g. json.HIVE keep working)
+		res.send(Object.assign({ success: true, message: 'Authentication successful!', token: token, userdata: account[bchain] }, account));
+	} catch (err) {
+		console.log(err);
+		res.send({ success: false, message: 'error' });
+	}
+});
+
 app.post('/loginAuth', loginRateLimit, async function (req, res) {
 	console.log('login');
 	let username = null;

--- a/app.js
+++ b/app.js
@@ -2006,7 +2006,7 @@ app.get('/recalculateUserTokens', checkHdrs, async function (req, res){
 				user_info.tokens = 0;
 			}
 
-			await db.collection('user_tokens').replaceOne({ user: user }, user_info, { upsert: true });
+			await db.collection('user_tokens').replaceOne({ _id: user }, user_info, { upsert: true });
 			res.send('success recalculating & updating user token count: ' + user_info.tokens);
 		} catch (err) {
 			console.error('Database Error:', err);
@@ -3547,7 +3547,7 @@ app.get('/buyAFITHive/:user/:amnt/:afitAmnt/:blockNo/:trxID/:bchain', async func
 		// We filter by user name to be safe, but you could also use { _id: user_info._id } 
 		// if you are certain the _id exists.
 		let trans = await db.collection('user_tokens').replaceOne(
-			{ user: user }, 
+			{ _id: user },
 			user_info, 
 			{ upsert: true }
 		);
@@ -3610,9 +3610,9 @@ app.get('/cancelAFITBuy', async function(req, res){
 
 	try {
 		// 3. Replace .save() with replaceOne
-		// We filter by 'user' to ensure we update the correct record
+		// user_tokens is keyed by _id (username); filter by _id
 		await db.collection('user_tokens').replaceOne(
-			{ user: user }, 
+			{ _id: user },
 			user_info, 
 			{ upsert: true }
 		);
@@ -3683,10 +3683,9 @@ app.get('/refundPurchase', async function(req, res){
 
 	try {
 		// 3. Swap .save() for .replaceOne()
-		// Using { user: user } as the filter ensures we hit the right record 
-		// even if the _id isn't present in a new object.
+		// user_tokens is keyed by _id (username); filter by _id
 		await db.collection('user_tokens').replaceOne(
-			{ user: user }, 
+			{ _id: user },
 			user_info, 
 			{ upsert: true }
 		);
@@ -4354,9 +4353,9 @@ app.post('/purchaseRealProduct/', checkHdrs, async function (req, res) {
 
 			try {
 				// Replace .save() with replaceOne
-				// We use { user: user } or { _id: user_info._id } to identify the user record
+				// user_tokens is keyed by _id (username); filter by _id
 				await db.collection('user_tokens').replaceOne(
-					{ user: user_info.user }, 
+					{ _id: user_info._id },
 					user_info, 
 					{ upsert: true }
 				);
@@ -4802,9 +4801,9 @@ async function performMultiBuyTrx(req){
 
 		try {
 			// Replace .save() with .replaceOne()
-			// Using { user: user_info.user } is safer if _id is somehow missing
+			// user_tokens is keyed by _id (username); filter by _id
 			await db.collection('user_tokens').replaceOne(
-				{ user: user_info.user }, 
+				{ _id: user_info._id },
 				user_info, 
 				{ upsert: true }
 			);
@@ -5980,8 +5979,8 @@ app.post('/tipAccount', checkHdrs, modActionRateLimit, async function(req, res){
 		try {
 			// Replace .save() with replaceOne
 			await db.collection('user_tokens').replaceOne(
-				{ user: user_info.user }, 
-				user_info, 
+				{ _id: user_info._id },
+				user_info,
 				{ upsert: true }
 			);
 			console.log('success updating sender token count');
@@ -6013,8 +6012,8 @@ app.post('/tipAccount', checkHdrs, modActionRateLimit, async function(req, res){
 		try {
 			// Replace .save() with replaceOne
 			await db.collection('user_tokens').replaceOne(
-				{ user: targetUser }, 
-				target_user_info, 
+				{ _id: targetUser },
+				target_user_info,
 				{ upsert: true }
 			);
 			console.log('success updating target user token count');
@@ -7102,55 +7101,43 @@ app.get('/confirmAFITSEBulk', async function(req,res){
 					date: new Date(entry.timestamp * 1000) //timestamp linux convert to seconds first
 				}
 				try{
-					console.log(tokenExchangeTrans);
-					//insert the query ensuring we do not write it twice
-					// 1. Update the transaction record
-					// Changed .update() to .replaceOne()
-					let transaction = await db.collection('token_transactions').replaceOne(
-						tokenExchangeTransQuery, 
-						tokenExchangeTrans, 
-						{ upsert: true }
-					);
-
-					// 2. Check for success (Modern driver returns metadata directly)
-					console.log(transaction);
-
-					// In the new driver, we check 'upsertedCount' instead of 'result.upserted'
-					if (transaction.upsertedCount > 0) {
-						// we have a new entry, increase user token count
+					// Idempotency guard: only process if this trx has NOT been recorded before.
+					// We credit the balance FIRST, then write the dedup record, so a failed
+					// credit does not permanently strand the deposit (it is retried next run).
+					let existingTrx = await db.collection('token_transactions').findOne(tokenExchangeTransQuery);
+					if (!existingTrx) {
+						// new entry, increase user token count
 						let user_info = await grabUserTokensFunc(user);
-						
-						let cur_user_token_count = 0;
 						if (user_info) {
-							cur_user_token_count = parseFloat(user_info.tokens) || 0;
-							
+							let cur_user_token_count = parseFloat(user_info.tokens) || 0;
+
 							// update current user's token balance & store to db
 							let afit_amount = parseFloat(entry.quantity) || 0;
 							let new_token_count = cur_user_token_count + afit_amount;
 							user_info.tokens = new_token_count;
-							
+
 							console.log('new_token_count:' + new_token_count);
-							
-							try {
-								// FIX: Replace .save() with .replaceOne()
-								await db.collection('user_tokens').replaceOne(
-									{ user: user_info.user }, 
-									user_info, 
-									{ upsert: true }
-								);
-								console.log('success adding AFIT tokens to user balance');
-							} catch (err) {
-								console.error('Error saving user tokens:', err);
-								return;
-							}
+
+							// 1. Credit the user balance. user_tokens is keyed by _id (username),
+							//    so we MUST filter by _id, not by a non-existent 'user' field.
+							await db.collection('user_tokens').replaceOne(
+								{ _id: user },
+								user_info,
+								{ upsert: true }
+							);
+							console.log('success adding AFIT tokens to user balance');
+
+							// 2. Only after a successful credit, record the dedup transaction
+							await db.collection('token_transactions').replaceOne(
+								tokenExchangeTransQuery,
+								tokenExchangeTrans,
+								{ upsert: true }
+							);
+							console.log(tokenExchangeTrans);
 						}
 					}
-					
 				}catch(err){
 					console.log(err);
-					res.write(JSON.stringify({'error': 'Error adding AFIT tokens to user balance'}));
-					res.end();
-					return;
 				}
 			}
 		});
@@ -7337,8 +7324,8 @@ app.get('/confirmAFITSEReceipt', checkHdrs, async function(req,res){
 								// FIX: Replace .save() with .replaceOne()
 								// We filter by user to ensure we hit the right record
 								await db.collection('user_tokens').replaceOne(
-									{ user: targetUser }, 
-									user_info, 
+									{ _id: targetUser },
+									user_info,
 									{ upsert: true }
 								);
 								console.log('success adding AFIT tokens to user balance');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-curation-bot",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-curation-bot",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-curation-bot",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "actifit curation bot",
   "main": "app.js",
   "dependencies": {

--- a/scripts/backfill_missing_deposits.js
+++ b/scripts/backfill_missing_deposits.js
@@ -1,0 +1,82 @@
+/**
+ * backfill_missing_deposits.js
+ *
+ * One-off recovery for AFIT deposits to actifit.h-e that were never processed
+ * because /confirmAFITSEBulk was auth-gated on 2026-05-21 (commit e46d9db) while
+ * the scheduler kept calling it without the admin_ops_token. Those deposits have
+ * NO token_transactions ledger row and were never credited.
+ *
+ * This replicates exactly what /confirmAFITSEBulk does per entry:
+ *   - insert ledger row { user, reward_activity:'Move AFIT HE to Actifit Wallet',
+ *       token_count, se_trx_ref, exchange:'HE', date }
+ *   - increment user_tokens.tokens by the deposit quantity (filter { _id: user })
+ *
+ * Idempotent: skips any deposit that already has a ledger row (se_trx_ref).
+ *
+ * USAGE:
+ *   node scripts/backfill_missing_deposits.js            # DRY RUN (no writes)
+ *   node scripts/backfill_missing_deposits.js --commit   # apply credits
+ */
+
+const { MongoClient } = require('mongodb');
+const config = require('../config.json');
+
+const COMMIT = process.argv.includes('--commit');
+const SINCE = '2026-02-12';
+const HE_ACCOUNT = config.hive_engine_actifit_he || 'actifit.h-e';
+const HISTORY_URL = `https://history.hive-engine.com/accountHistory?account=${HE_ACCOUNT}&symbol=AFIT&limit=500`;
+const INTERNAL = new Set([HE_ACCOUNT, 'actifit', 'afitx.h-e', 'actifit.tip']);
+
+(async () => {
+	const sinceTs = Math.floor(new Date(SINCE + 'T00:00:00Z').getTime() / 1000);
+	const client = new MongoClient(config.testing ? config.mongo_local : config.mongo_uri);
+	await client.connect();
+	const db = client.db(config.db_name);
+
+	try {
+		const rows = await (await fetch(HISTORY_URL)).json();
+		const deposits = rows
+			.filter(x => x.to === HE_ACCOUNT && x.symbol === 'AFIT' && !INTERNAL.has(x.from) && (x.timestamp || 0) >= sinceTs)
+			.sort((a, b) => a.timestamp - b.timestamp);
+
+		console.log(`${COMMIT ? 'COMMIT' : 'DRY RUN'} | scanning ${deposits.length} on-chain deposits since ${SINCE}\n`);
+
+		let credited = 0, skipped = 0, totalAfit = 0;
+		for (const d of deposits) {
+			const user = d.from;
+			const query = { user, se_trx_ref: d.transactionId };
+			const existing = await db.collection('token_transactions').findOne(query);
+			if (existing) { skipped++; continue; }
+
+			const qty = parseFloat(d.quantity) || 0;
+			const before = await db.collection('user_tokens').findOne({ _id: user });
+			const beforeBal = before ? parseFloat(before.tokens) || 0 : 0;
+			const afterBal = beforeBal + qty;
+
+			console.log(`CREDIT ${user.padEnd(16)} +${qty.toFixed(3).padStart(11)}  ${beforeBal.toFixed(3)} -> ${afterBal.toFixed(3)}  (${d.transactionId})`);
+			totalAfit += qty; credited++;
+
+			if (COMMIT) {
+				// 1. ledger row (mirrors handler shape)
+				await db.collection('token_transactions').replaceOne(query, {
+					user,
+					reward_activity: 'Move AFIT HE to Actifit Wallet',
+					token_count: qty,
+					se_trx_ref: d.transactionId,
+					exchange: 'HE',
+					date: new Date(d.timestamp * 1000)
+				}, { upsert: true });
+
+				// 2. balance increment (keyed by _id)
+				const doc = before || { _id: user, name: user, user, tokens: 0 };
+				doc.tokens = afterBal;
+				await db.collection('user_tokens').replaceOne({ _id: user }, doc, { upsert: true });
+			}
+		}
+
+		console.log(`\n${COMMIT ? 'Applied' : 'Would credit'}: ${credited} deposit(s), ${totalAfit.toFixed(3)} AFIT | already-processed skipped: ${skipped}`);
+		if (!COMMIT && credited) console.log('Re-run with --commit to apply.');
+	} finally {
+		await client.close();
+	}
+})().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/reconcile_deposits.js
+++ b/scripts/reconcile_deposits.js
@@ -1,0 +1,130 @@
+/**
+ * reconcile_deposits.js
+ *
+ * Finds AFIT deposits to actifit.h-e that were recorded in the token_transactions
+ * ledger but never credited to the user's running balance (user_tokens.tokens),
+ * caused by the wrong replaceOne filter ({ user: ... } instead of { _id: ... })
+ * introduced in commit 7ba9bf2 (2026-02-12).
+ *
+ * For every affected user it compares:
+ *   ledgerSum  = SUM(token_count) over all token_transactions for the user
+ *   stored     = user_tokens.tokens (the running balance shown to the user)
+ *
+ * This is exactly what /recalculateUserTokens does. If ledgerSum > stored, the
+ * user is missing credits (the stranded deposits live in the ledger already).
+ *
+ * USAGE:
+ *   node scripts/reconcile_deposits.js                 # read-only report
+ *   node scripts/reconcile_deposits.js --fix           # set tokens = ledgerSum for mismatched users
+ *   node scripts/reconcile_deposits.js --since 2026-02-12   # window for the on-chain deposit scan
+ *   node scripts/reconcile_deposits.js --tolerance 0.001    # ignore tiny float diffs (default 0.001)
+ *
+ * Read-only by default. --fix mirrors the existing /recalculateUserTokens logic
+ * (balance := ledger sum), so it cannot double-credit and is idempotent.
+ */
+
+const { MongoClient } = require('mongodb');
+const config = require('../config.json');
+
+const args = process.argv.slice(2);
+const DO_FIX = args.includes('--fix');
+const getArg = (name, def) => {
+	const i = args.indexOf(name);
+	return i >= 0 && args[i + 1] ? args[i + 1] : def;
+};
+const SINCE = getArg('--since', '2026-02-12');
+const TOLERANCE = parseFloat(getArg('--tolerance', '0.001'));
+const HE_ACCOUNT = config.hive_engine_actifit_he || 'actifit.h-e';
+const HISTORY_URL = `https://history.hive-engine.com/accountHistory?account=${HE_ACCOUNT}&symbol=AFIT&limit=500`;
+const INTERNAL = new Set([HE_ACCOUNT, 'actifit', 'afitx.h-e', 'actifit.tip']);
+
+async function fetchDeposits(sinceTs) {
+	const res = await fetch(HISTORY_URL);
+	const rows = await res.json();
+	return rows.filter(x =>
+		x.to === HE_ACCOUNT &&
+		x.symbol === 'AFIT' &&
+		!INTERNAL.has(x.from) &&
+		(x.timestamp || 0) >= sinceTs
+	);
+}
+
+(async () => {
+	const sinceTs = Math.floor(new Date(SINCE + 'T00:00:00Z').getTime() / 1000);
+	const url = config.testing ? config.mongo_local : config.mongo_uri;
+	const client = new MongoClient(url);
+
+	try {
+		await client.connect();
+		const db = client.db(config.db_name);
+
+		// 1. on-chain deposits in the window -> set of users who deposited
+		const deposits = await fetchDeposits(sinceTs);
+		const depositors = [...new Set(deposits.map(d => d.from))].sort();
+		console.log(`On-chain AFIT deposits to ${HE_ACCOUNT} since ${SINCE}: ${deposits.length} from ${depositors.length} users\n`);
+
+		// 2. for each depositor, compare ledger sum vs stored running balance
+		const mismatches = [];
+		for (const user of depositors) {
+			const agg = await db.collection('token_transactions').aggregate([
+				{ $match: { user } },
+				{ $group: { _id: null, token_balance: { $sum: '$token_count' } } }
+			]).toArray();
+			let ledgerSum = agg.length ? parseFloat(agg[0].token_balance) : 0;
+			if (ledgerSum < 0) ledgerSum = 0;
+
+			const doc = await db.collection('user_tokens').findOne({ _id: user });
+			const stored = doc ? parseFloat(doc.tokens) || 0 : 0;
+
+			// did the in-window deposits actually land in the ledger?
+			const userDeps = deposits.filter(d => d.from === user);
+			const missingLedger = [];
+			for (const d of userDeps) {
+				const row = await db.collection('token_transactions').findOne({ user, se_trx_ref: d.transactionId });
+				if (!row) missingLedger.push(d.transactionId);
+			}
+
+			const diff = ledgerSum - stored;
+			if (Math.abs(diff) > TOLERANCE || missingLedger.length) {
+				mismatches.push({ user, stored, ledgerSum, diff, missingLedger });
+			}
+		}
+
+		// 3. report
+		if (!mismatches.length) {
+			console.log('No discrepancies found. All depositor balances match their ledger.');
+		} else {
+			console.log('USER                 STORED         LEDGER          DIFF   MISSING_LEDGER_ROWS');
+			console.log('-'.repeat(92));
+			for (const m of mismatches) {
+				console.log(
+					`${m.user.padEnd(20)} ${m.stored.toFixed(3).padStart(12)} ${m.ledgerSum.toFixed(3).padStart(13)} ${m.diff.toFixed(3).padStart(13)}   ${m.missingLedger.length ? m.missingLedger.join(',') : '-'}`
+				);
+			}
+			console.log('-'.repeat(92));
+			const totalUnderCredited = mismatches.filter(m => m.diff > 0).reduce((s, m) => s + m.diff, 0);
+			console.log(`Users off: ${mismatches.length} | net under-credited (ledger>stored): ${totalUnderCredited.toFixed(3)} AFIT`);
+			const anyMissing = mismatches.filter(m => m.missingLedger.length);
+			if (anyMissing.length) {
+				console.log(`\n⚠ ${anyMissing.length} user(s) have deposits with NO ledger row at all — those cannot be`);
+				console.log(`  recovered by recalculation; they must be credited manually from the on-chain tx.`);
+			}
+		}
+
+		// 4. optional fix: balance := ledger sum (same as /recalculateUserTokens)
+		if (DO_FIX && mismatches.length) {
+			console.log('\n--fix: setting user_tokens.tokens = ledgerSum for mismatched users...');
+			for (const m of mismatches) {
+				const doc = (await db.collection('user_tokens').findOne({ _id: m.user })) || { _id: m.user, name: m.user };
+				doc.tokens = m.ledgerSum;
+				await db.collection('user_tokens').replaceOne({ _id: m.user }, doc, { upsert: true });
+				console.log(`  ${m.user}: ${m.stored.toFixed(3)} -> ${m.ledgerSum.toFixed(3)}`);
+			}
+			console.log('Done. (Users with missing ledger rows still need manual crediting.)');
+		} else if (mismatches.length) {
+			console.log('\nRead-only run. Re-run with --fix to apply, or call /recalculateUserTokens for each listed user.');
+		}
+	} finally {
+		await client.close();
+	}
+})().catch(err => { console.error(err); process.exit(1); });

--- a/utils.js
+++ b/utils.js
@@ -365,7 +365,7 @@ var HOURS = 60 * 60;
 
 					//connect with our service to confirm AFIT received to proper wallet
 					try{
-						let se_connector = await fetch(url);
+						let se_connector = await fetch(url, { signal: AbortSignal.timeout(15000) });
 						let trx_entries = await se_connector.json();
 						console.log(trx_entries);
 						let match_trx;
@@ -434,7 +434,7 @@ var HOURS = 60 * 60;
 		let url = new URL(config.hive_engine_tip_trans_his);
 		//connect with our service to confirm AFIT received to proper wallet
 		try{
-			let he_connector = await fetch(url);
+			let he_connector = await fetch(url, { signal: AbortSignal.timeout(15000) });
 			let trx_entries = await he_connector.json();
 			
 			for (const entry of trx_entries){
@@ -539,7 +539,7 @@ var HOURS = 60 * 60;
 
 					//connect with our service to confirm AFIT received to proper wallet
 					try{
-						let se_connector = await fetch(url);
+						let se_connector = await fetch(url, { signal: AbortSignal.timeout(15000) });
 						let trx_entries = await se_connector.json();
 						
 						let match_trx;


### PR DESCRIPTION
## Summary
Release of current `develop` to production.

- **feat(api): `/loginKeychainVerify`** — verifies the keychain-decrypted challenge (proof of posting-key ownership) and issues a 30-day session JWT stored in `user_login_token`. Fixes Keychain logins previously storing a client-side random token that failed `checkHdrs`, so authenticated POSTs (e.g. `setUserFundsPass`) returned "Token is not valid". Pairs with actifit-landingpage PR #288.
- fix: respond on `confirmAFITSEBulk` failure + add timeouts to history fetches.
- chore: idempotent deposit backfill recovery script.
- fix: credit AFIT deposits by `_id`, not the non-existent `user` field.

Version bumped to 0.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)