### PR TITLE
ci: make deploy resilient to server-side package-lock churn

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,12 @@ jobs:
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           script: |
+            set -e
             cd /home/actifit-bot
+            # npm install --production rewrites package-lock.json on the server, leaving the
+            # working tree dirty and blocking git pull whenever a release touches the lock.
+            # discard that churn (only the lock) so the pull always applies cleanly.
+            git checkout -- package-lock.json || true
             git pull origin master
             npm install --production
             pm2 restart app


### PR DESCRIPTION
## Why
The previous release (#29) deployed but the new `/loginKeychainVerify` route was 404 in production. The deploy run "succeeded" but the SSH log shows on both servers:

```
error: Your local changes to the following files would be overwritten by merge:
	package-lock.json
Aborting
```

`npm install --production` rewrites `package-lock.json` on each server, leaving the working tree dirty. Because the release bumped the lock, `git pull` aborted — and since the deploy script wasn't `set -e`/`&&`-chained, it still ran `pm2 restart app` on the **old code** and reported success.

## Fix
- `git checkout -- package-lock.json` before pulling, to discard the server-side lock churn (only the lock, nothing else).
- `set -e` so a failed pull actually fails the workflow instead of silently restarting stale code.

Merging this re-runs the deploy with the fix, which self-heals the dirty working tree and finally lands `loginKeychainVerify` (already on master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)