### PR TITLE
Deploy: RC delegation tooling + daily AFIT->H-E move fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ logs
 npm-debug.log*
 state.json
 config.json
+rc_delegations_config.json
 
 # Runtime data
 pids

--- a/RC_DELEGATIONS_README.md
+++ b/RC_DELEGATIONS_README.md
@@ -1,0 +1,140 @@
+# RC Delegations — Cancel Outgoing Delegations from `actifit.pay`
+
+Cancels outgoing **RC (Resource Credit) direct delegations** from the pay account
+(`actifit.pay`) by re-delegating each with `max_rc: 0`.
+
+This is the runnable replacement for the old `rc_delegations_script.txt` snapshot
+(which had no imports, no node setup, and an empty key). The private key lives in a
+**separate, gitignored config file** — never in the script.
+
+Files:
+
+| File | Purpose |
+| --- | --- |
+| `rc_delegations_cancel.js` | The runnable script |
+| `rc_delegations_config.example.json` | Config template (safe to commit) |
+| `rc_delegations_config.json` | **Your real config with the private key** (gitignored) |
+
+---
+
+## 1. Setup
+
+```bash
+cd actifitbot
+cp rc_delegations_config.example.json rc_delegations_config.json
+```
+
+Then edit `rc_delegations_config.json` and set `pay_account_posting_key`.
+
+> **Which key?** RC delegation is authorized by the account's **private POSTING
+> key** (the op uses `required_posting_auths: ['actifit.pay']`) — *not* the active
+> key. This is the same value your main `config.json` stores as
+> `pay_account_posting_key`.
+
+`rc_delegations_config.json` is already in `.gitignore` (next to `config.json`), so
+the key won't be committed.
+
+---
+
+## 2. Run
+
+Via npm:
+
+```bash
+npm run rc-cancel
+```
+
+Or directly:
+
+```bash
+node rc_delegations_cancel.js
+```
+
+By default the config ships with `"dry_run": true`, so the first run **only logs
+what it would cancel** and broadcasts nothing. Review that output, then go live.
+
+### CLI flags
+
+| Flag | Effect |
+| --- | --- |
+| `--dry-run` | Force a dry run (log only, no broadcast) — overrides config |
+| `--live` | Force a real broadcast — overrides config |
+| `--recent` | Order by recency (keep the newest delegations) — overrides config |
+| `--config <path>` | Use a different config file (default `./rc_delegations_config.json`) |
+
+Typical flow:
+
+```bash
+# 1. See what would happen — dry run + recency ordering are both defaults
+node rc_delegations_cancel.js
+
+# 2. When satisfied, actually cancel (keeps the newest `keep_recent`)
+node rc_delegations_cancel.js --live
+```
+
+---
+
+## 3. Config reference (`rc_delegations_config.json`)
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `pay_account` | `actifit.pay` | Account whose outgoing RC delegations are cancelled |
+| `pay_account_posting_key` | — | **Private posting key** of `pay_account` (required for `--live`) |
+| `active_hive_node` | `https://api.hive.blog` | Primary Hive API node |
+| `alt_hive_nodes` | *(list)* | Fallback nodes |
+| `excludeList` | *(list)* | Accounts that must **never** be cancelled (exact account names) |
+| `min_total_to_run` | `60` | Only run if there are **more** than this many active delegations |
+| `keep_recent` | `20` | Leave this many delegations untouched (throttle — see below) |
+| `delay_ms` | `3000` | Delay between broadcasts, in ms (avoids rate/RC issues) |
+| `dry_run` | `true` | If true, log only — no broadcast |
+| `order` | `recent` | `recent` (chronological) or `account` (alphabetical) — see below |
+| `history_scan_limit` | `100000` | Max account-history ops to scan when `order: recent` |
+
+---
+
+## 4. How it decides what to cancel
+
+1. **Fetch** all active RC delegations from `actifit.pay` (paginated, 1000/page).
+2. **Bail** if the total is `<= min_total_to_run`.
+3. **Order** the list (see below).
+4. **Keep** the last `keep_recent` entries untouched.
+5. **Cancel** the rest — but always **skip anything in `excludeList`**.
+6. Wait `delay_ms` between each broadcast.
+
+### `keep_recent` is a throttle
+
+The script intentionally leaves `keep_recent` delegations in place each run. This
+lets you drain a large delegation set over **several runs** instead of firing
+hundreds of ops at once. To cancel *everything* in one pass, set `keep_recent: 0`.
+
+### `excludeList` is always honored
+
+An excluded account is never cancelled, regardless of `order` — if it lands in the
+cancel range it's skipped; if it lands in the kept tail it's never reached. Match
+names **exactly** as they appear on-chain (e.g. `actifit.h-e`, not `actifit-he`).
+
+### Ordering: `account` vs `recent`
+
+- **`recent`** (default): reconstructs the real chronological order by scanning
+  `actifit.pay`'s account history for the `delegate_rc` ops (the RC API carries no
+  timestamp). Delegations are then sorted **oldest-first**, so `keep_recent` keeps
+  the **genuinely newest** and cancellation drains the oldest first.
+- **`account`**: the order returned by the RC API, which is alphabetical by
+  delegatee name — effectively arbitrary with respect to time. Cheaper (no history
+  scan); use it if you don't care which delegations are kept vs. cancelled.
+
+`recent` mode reads account history in pages until every active delegatee is dated,
+bounded by `history_scan_limit`. Any delegatee not found within that cap is treated
+as oldest (cancelled first) and the script prints a note. This cap only exists to
+prevent an unbounded deep scan on a very busy account; it does not change how many
+delegations get cancelled.
+
+---
+
+## 5. Safety notes
+
+- **Always dry-run first.** The default config does this for you.
+- The key file `rc_delegations_config.json` is gitignored — keep it that way.
+- Cancelling an RC delegation sets the recipient's delegated RC to 0; it does not
+  affect HP (vesting) delegations.
+- `delay_ms` spaces out broadcasts; lowering it too far risks node rate limits.

--- a/app.js
+++ b/app.js
@@ -5878,7 +5878,7 @@ app.post('/initiateAFITMoveSE', checkHdrs, modActionRateLimit, async function(re
 		let tokenPowerDownTrans = {
 			user: user,
 			daily_afit_transfer: amount,
-			min_afitx: (amount - config.free_movable_afit_day) / config.afitx_afit_move_ratio,
+			min_afitx: Math.max(0, (amount - config.free_movable_afit_day) / config.afitx_afit_move_ratio),
 			date: new Date(),
 		}
 		

--- a/delegations.js
+++ b/delegations.js
@@ -88,29 +88,33 @@ if (process.env.BOT_THREAD == 'MAIN'){
 	
 	
 }else */
+// Only auto-run the scheduler / reward pipeline when executed directly
+// (node delegations.js / pm2). When required by a test, skip bootstrap so the
+// exported functions can be exercised in isolation.
+if (require.main === module) {
 if (process.env.BOT_THREAD == 'MAIN'){
-	
+
 	console.log('>>>>>>>>>MAIN DELEGATION THREAD<<<<<<<<<<<')
 	
-	var j = schedule.scheduleJob({hour: 08, minute: 00}, function(){
+	var j = schedule.scheduleJob({hour: 8, minute: 0}, function(){
 	  console.log('--- Start delegators reward ---');
 	  runRewards(false, true);//param steemOnlyReward, updateDelegations
 	});
 	
 	//let's schedule the AFIT to S-E token move event at 10:00 
-	let moveJob = schedule.scheduleJob({hour: 10, minute: 00}, function(){
+	let moveJob = schedule.scheduleJob({hour: 10, minute: 0}, function(){
 	  console.log('--- Start AFIT to S-E Move ---');
 	  moveAFITToSE(false);//param test
 	});
 	
 	//schedule the prize event at 00:00 every X days
-	let prizeJob = schedule.scheduleJob({hour: 00, minute: 01}, function(){
+	let prizeJob = schedule.scheduleJob({hour: 0, minute: 1}, function(){
 	  console.log('--- Reward Gadget Buy Contest ---');
 	  processGadgetBuyPrize();//param test
 	});
 	
 	//schedule the delegation cancellation event at 11:00 every day
-	let delegCancellation = schedule.scheduleJob({hour: 11, minute: 00}, function(){
+	let delegCancellation = schedule.scheduleJob({hour: 11, minute: 0}, function(){
 	  console.log('--- Cancel outdated delegations ---');
 	  utils.redeemDelegations();
 	});
@@ -152,9 +156,10 @@ if (process.env.BOT_THREAD == 'MAIN'){
 	console.log(val);*/
 	//testFetchHistory();
 	//processBSCTransfers();
-	
-	
+
+
 }
+} // end require.main bootstrap guard
 /*
 async function testFetchHistory(){
 	let from = -1
@@ -307,7 +312,8 @@ async function updateTrxDetails(entry, trxHash, afitAmnt, hbdAmnt){
 	entry.hbdLockedAmount = pendingHbd;
 	entry.trfDate = new Date();
 	try{
-		let trans = await db.collection('bsc_bridge_queue').save(entry);
+		//driver 5.x: .save() removed - replace the existing doc by _id
+		let trans = await db.collection('bsc_bridge_queue').replaceOne({_id: entry._id}, entry);
 		console.log('success updating BSC transfer trx');
 	}catch(err){
 		console.log(err);
@@ -624,7 +630,8 @@ async function testMove(){
 async function rollBackTrans(moveTrans){
 	console.log('roll back')
 	try{
-		let transaction = await db.collection('token_transactions').remove(moveTrans);
+		//driver 5.x: .remove() removed - delete the doc inserted for this move
+		let transaction = await db.collection('token_transactions').deleteOne({_id: moveTrans._id});
 	}catch(err){
 		console.log(err);
 	}
@@ -639,7 +646,8 @@ async function updateUserCount(entry){
 	user_info.tokens = new_token_count;
 	console.log('user:' + entry.user + 'new_token_count:'+new_token_count);
 	try{
-		let trans = await db.collection('user_tokens').save(user_info);
+		//driver 5.x: .save() removed - replace the user's token doc by _id
+		let trans = await db.collection('user_tokens').replaceOne({_id: user_info._id}, user_info);
 		console.log('success updating user token count');
 	}catch(err){
 		console.log(err);
@@ -685,7 +693,17 @@ async function moveAFITToSE(testMode){
 		console.log(afit_av_bal);
 		//loop through entries, and send over AFIT
 		poweringDown.forEach(async function(entry){
-			
+
+			//expire stale requests (older than the powerdown window) WITHOUT moving funds,
+			//so month-old leftovers get cleaned up instead of lingering / moving indefinitely
+			let winStart = moment().utc().startOf('date').toDate();
+			let expiryCutoff = moment(winStart).subtract(config.afit_powerdown_days || 7, 'days').format();
+			if (moment(new Date(entry.date)).format() < expiryCutoff){
+				console.log('expiring stale AFIT power down request for ' + entry.user + ' (dated ' + entry.date + ')');
+				await cancelDailyAFITPowerDown(entry, testMode, null);
+				return;
+			}
+
 			//let's make sure user is not banned
 			let user_banned = false;
 			for (let n = 0; n < banned_users.length; n++) {
@@ -852,7 +870,20 @@ async function moveAFITToSE(testMode){
 					}, delay+=4500);
 				}else{
 					console.log('error - user does not have enough funds');
-					await deactivateDailyAFITPowerDown(entry, testMode);
+					//work out which balance fell short so we can tell the user precisely
+					let cancelMsg;
+					let neededAfitx = (amount - config.free_movable_afit_day) / config.afitx_afit_move_ratio;
+					if (amount > config.free_movable_afit_day && neededAfitx > afitx_tot_bal){
+						cancelMsg = 'Your daily move of ' + amount + ' AFIT to Hive-Engine was cancelled: moving that ' +
+							'amount requires at least ' + neededAfitx.toFixed(3) + ' AFITX, but you only hold ' +
+							afitx_tot_bal + ' AFITX. Top up your AFITX and set up the move again.';
+					}else{
+						cancelMsg = 'Your daily move of ' + amount + ' AFIT to Hive-Engine was cancelled: your Actifit ' +
+							'AFIT balance (' + cur_user_token_count + ') is below the requested ' + amount +
+							' AFIT/day. Earn or top up more AFIT and set up the move again.';
+					}
+					//notify the user and remove the request so it stops retrying daily
+					await cancelDailyAFITPowerDown(entry, testMode, cancelMsg);
 					return;
 				}
 			}else{
@@ -872,8 +903,8 @@ async function deactivateDailyAFITPowerDown(entry, testMode){
 	let start = moment().utc().startOf('date').toDate()
 	
 	//7 days running timeframe
-	let to = moment(start).subtract(7, 'days').toDate()
-	
+	let to = moment(start).subtract(config.afit_powerdown_days || 7, 'days').toDate()
+
 	let maxDate = moment(to).format()
 	
 	let transDate = moment(new Date(entry.date)).format();
@@ -886,10 +917,33 @@ async function deactivateDailyAFITPowerDown(entry, testMode){
     if (transDate < maxDate) {// || entry.user=='mcfarhat'
 		console.log('need to cancel out transaction')
 		if (!testMode){// || entry.user=='mcfarhat'
-			let stts = await db.collection('powering_down_he').remove(entry);
+			//driver 5.x: .remove() no longer exists, use deleteOne by _id
+			let stts = await db.collection('powering_down_he').deleteOne({_id: entry._id});
 		}
 	}
-	
+
+}
+
+//immediately cancel a pending daily AFIT move (e.g. insufficient funds / stale) and
+//optionally notify the user why. Unlike deactivateDailyAFITPowerDown this does not wait
+//for the 7-day window - the request is removed right away so it stops retrying daily.
+async function cancelDailyAFITPowerDown(entry, testMode, message){
+	console.log('cancelling daily AFIT power down for ' + entry.user + (message ? ' : ' + message : ''));
+	if (testMode) return;
+	try{
+		//remove the pending request first so it stops retrying every day
+		await db.collection('powering_down_he').deleteOne({_id: entry._id});
+		//notify the user why it was cancelled (skip for silent expiry cleanups)
+		if (message){
+			await utils.sendNotification(
+				db, entry.user, 'actifit',
+				'afit_move_cancelled', 'afit_move_cancelled',
+				message, 'https://actifit.io/@' + entry.user
+			);
+		}
+	}catch(err){
+		console.log('error cancelling daily AFIT power down: ' + err);
+	}
 }
 
 /*
@@ -1948,3 +2002,15 @@ async function claimRewards(){
 		console.log('no rewards to claim for now');
 	}
 }
+
+// Exported for testing. The bootstrap above is guarded by require.main so this
+// module can be required in tests without launching the scheduler/pipeline.
+module.exports = {
+	moveAFITToSE,
+	deactivateDailyAFITPowerDown,
+	cancelDailyAFITPowerDown,
+	updateUserCount,
+	rollBackTrans,
+	// inject a (mock) db into the module-level `db` used by the functions above
+	__setTestDb: (mockDb) => { db = mockDb; },
+};

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "test:coverage": "jest --coverage",
     "heroku-postbuild": "node heroku-setup.js",
     "delegate": "node delegations.js",
+    "rc-cancel": "node rc_delegations_cancel.js",
     "api": "node app.js",
     "all": "node app.js | node delegations.js ",
     "start": "node app.js"

--- a/rc_delegations_cancel.js
+++ b/rc_delegations_cancel.js
@@ -1,0 +1,241 @@
+/*
+ * rc_delegations_cancel.js
+ *
+ * Cancels outgoing RC (Resource Credit) direct delegations from the pay account
+ * (actifit.pay) by re-delegating with max_rc: 0.
+ *
+ * This is the runnable version of rc_delegations_script.txt. It loads its
+ * credentials from a SEPARATE config file (rc_delegations_config.json) so the
+ * private key never lives inside the script.
+ *
+ * RC delegation is authorized by the account's POSTING key
+ * (required_posting_auths), matching the working delegateRC() in utils.js.
+ *
+ * Setup:
+ *   cp rc_delegations_config.example.json rc_delegations_config.json
+ *   # edit rc_delegations_config.json -> set pay_account_posting_key
+ *
+ * Run:
+ *   node rc_delegations_cancel.js                 # uses dry_run from config
+ *   node rc_delegations_cancel.js --live          # force real broadcast
+ *   node rc_delegations_cancel.js --dry-run       # force dry run (no broadcast)
+ *   node rc_delegations_cancel.js --recent        # order by recency (keep newest)
+ *   node rc_delegations_cancel.js --config path   # use a different config file
+ */
+
+const fs = require('fs');
+const hive = require('@hiveio/hive-js');
+
+// ---- load separate config -------------------------------------------------
+function loadConfig() {
+  const args = process.argv.slice(2);
+  const cfgFlagIdx = args.indexOf('--config');
+  const cfgPath = cfgFlagIdx !== -1 ? args[cfgFlagIdx + 1] : './rc_delegations_config.json';
+
+  if (!fs.existsSync(cfgPath)) {
+    console.error('Missing config file: ' + cfgPath);
+    console.error('Copy rc_delegations_config.example.json to rc_delegations_config.json and set pay_account_posting_key.');
+    process.exit(1);
+  }
+
+  const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+
+  // CLI overrides for the dry_run flag
+  if (args.includes('--live')) cfg.dry_run = false;
+  if (args.includes('--dry-run')) cfg.dry_run = true;
+
+  // defaults
+  cfg.min_total_to_run = cfg.min_total_to_run != null ? cfg.min_total_to_run : 60;
+  cfg.keep_recent = cfg.keep_recent != null ? cfg.keep_recent : 20;
+  cfg.delay_ms = cfg.delay_ms != null ? cfg.delay_ms : 3000;
+  cfg.excludeList = cfg.excludeList || [];
+  cfg.order = cfg.order || 'recent'; // 'recent' (chronological) | 'account' (alphabetical)
+  cfg.history_scan_limit = cfg.history_scan_limit != null ? cfg.history_scan_limit : 100000;
+
+  // CLI overrides for ordering
+  if (args.includes('--recent')) cfg.order = 'recent';
+
+  if (!cfg.pay_account) {
+    console.error('config.pay_account is required');
+    process.exit(1);
+  }
+  if (!cfg.dry_run && (!cfg.pay_account_posting_key || cfg.pay_account_posting_key.indexOf('PUT_') === 0)) {
+    console.error('config.pay_account_posting_key is required for a live run. Set it in rc_delegations_config.json.');
+    process.exit(1);
+  }
+  return cfg;
+}
+
+const config = loadConfig();
+
+// ---- hive node setup ------------------------------------------------------
+if (config.alt_hive_nodes) {
+  hive.config.set('alternative_api_endpoints', config.alt_hive_nodes);
+}
+hive.api.setOptions({ url: config.active_hive_node || 'https://api.hive.blog' });
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// ---- fetch ALL outgoing RC direct delegations (paginated) -----------------
+async function fetchAllRCDelegations(fromAccount) {
+  const pageSize = 1000;
+  let all = [];
+  let start = [fromAccount, ''];
+
+  while (true) {
+    const res = await hive.api.callAsync('rc_api.list_rc_direct_delegations', { start, limit: pageSize });
+    const page = (res && res.rc_direct_delegations) || [];
+    if (page.length === 0) break;
+
+    // rc_api pagination returns the `start` row again as the first element of
+    // the next page; drop it to avoid double-processing.
+    const fresh = all.length > 0 ? page.slice(1) : page;
+    // only keep rows that actually belong to our delegator
+    const mine = fresh.filter((d) => d.from === fromAccount);
+    all = all.concat(mine);
+
+    if (page.length < pageSize) break;
+    const last = page[page.length - 1];
+    start = [last.from, last.to];
+  }
+  return all;
+}
+
+// ---- recency ordering via account history ---------------------------------
+// rc_api.list_rc_direct_delegations only sorts by account name and carries no
+// timestamp. To order by recency we scan the delegator's account history
+// (newest -> oldest) for `custom_json` id=rc / delegate_rc ops and record when
+// each currently-active delegatee was last set. First time we see a delegatee
+// walking backwards == its most recent delegation.
+async function fetchRecencyMap(delegator, activeToSet, maxOps) {
+  const pageSize = 1000;
+  const recency = new Map(); // delegatee -> { idx, ts }
+  const remaining = new Set(activeToSet);
+  let start = -1;
+  let scanned = 0;
+
+  while (scanned < maxOps && remaining.size > 0) {
+    const lim = start === -1 ? pageSize : Math.min(pageSize, start);
+    if (lim <= 0) break;
+
+    const txs = await hive.api.getAccountHistoryAsync(delegator, start, lim);
+    if (!txs || txs.length === 0) break;
+
+    // txs are ascending by index; walk newest -> oldest
+    for (let i = txs.length - 1; i >= 0; i--) {
+      const entry = txs[i][1];
+      scanned++;
+      const op = entry.op;
+      if (op[0] !== 'custom_json' || op[1].id !== 'rc') continue;
+      let parsed;
+      try { parsed = JSON.parse(op[1].json); } catch (e) { continue; }
+      if (parsed[0] !== 'delegate_rc' || !Array.isArray(parsed[1].delegatees)) continue;
+      for (const d of parsed[1].delegatees) {
+        if (remaining.has(d) && !recency.has(d)) {
+          recency.set(d, { idx: txs[i][0], ts: entry.timestamp });
+          remaining.delete(d);
+        }
+      }
+    }
+
+    const oldestIdx = txs[0][0];
+    if (oldestIdx <= 0) break; // reached the beginning of history
+    start = oldestIdx - 1;
+  }
+
+  if (remaining.size > 0) {
+    console.log('note: ' + remaining.size + ' active delegatee(s) not found within ' +
+      maxOps + ' history ops (scanned ' + scanned + '); treated as oldest.');
+  }
+  return recency;
+}
+
+// ---- cancel a single delegation (max_rc: 0) -------------------------------
+async function cancelDelegation(delegator, postingKey, targetUser) {
+  const json_data = JSON.stringify(['delegate_rc', {
+    from: delegator,
+    delegatees: [targetUser],
+    max_rc: 0,
+  }]);
+
+  return hive.broadcast.customJsonAsync(
+    postingKey,        // active/posting key string
+    [],                // required_auths
+    [delegator],       // required_posting_auths
+    'rc',              // custom_json id
+    json_data
+  );
+}
+
+// ---- main -----------------------------------------------------------------
+async function mainLooper() {
+  const delegator = config.pay_account;
+  console.log('--- RC delegation cancellation ---');
+  console.log('delegator      : ' + delegator);
+  console.log('node           : ' + (config.active_hive_node || 'https://api.hive.blog'));
+  console.log('dry_run        : ' + config.dry_run);
+
+  const activeRCDelegations = await fetchAllRCDelegations(delegator);
+  console.log('total active RC delegations: ' + activeRCDelegations.length);
+
+  if (activeRCDelegations.length <= config.min_total_to_run) {
+    console.log('Below min_total_to_run (' + config.min_total_to_run + '). Nothing to do.');
+    return;
+  }
+
+  // ordering: 'account' (default, alphabetical by delegatee) or 'recent'
+  // (chronological via account history — oldest first, so keep_recent keeps the newest)
+  if (config.order === 'recent') {
+    console.log('ordering by recency (scanning up to ' + config.history_scan_limit + ' history ops)...');
+    const activeSet = new Set(activeRCDelegations.map((d) => d.to));
+    const recency = await fetchRecencyMap(delegator, activeSet, config.history_scan_limit);
+    // ascending: oldest (or unknown) first, newest last
+    activeRCDelegations.sort((a, b) => {
+      const ra = recency.get(a.to);
+      const rb = recency.get(b.to);
+      const ia = ra ? ra.idx : -1;
+      const ib = rb ? rb.idx : -1;
+      return ia - ib;
+    });
+  }
+
+  // keep the last `keep_recent` entries untouched (throttle: drain over multiple runs)
+  const cutoff = activeRCDelegations.length - config.keep_recent;
+  const targets = [];
+  for (let j = 0; j < cutoff; j++) {
+    const to = activeRCDelegations[j].to;
+    if (config.excludeList.includes(to)) continue;
+    targets.push(to);
+  }
+
+  console.log('will cancel ' + targets.length + ' delegations (keeping last ' +
+    config.keep_recent + ', excluding ' + config.excludeList.length + ' accounts)');
+
+  let done = 0;
+  let failed = 0;
+  for (const to of targets) {
+    if (config.dry_run) {
+      console.log('[dry-run] would cancel RC delegation to ' + to);
+      done++;
+      continue;
+    }
+    try {
+      await cancelDelegation(delegator, config.pay_account_posting_key, to);
+      done++;
+      console.log('cancelled (' + done + '/' + targets.length + ') -> ' + to);
+    } catch (err) {
+      failed++;
+      console.log('FAILED -> ' + to + ' : ' + (err && err.message ? err.message : err));
+    }
+    await sleep(config.delay_ms);
+  }
+
+  console.log('--- done. cancelled: ' + done + ', failed: ' + failed + ' ---');
+}
+
+mainLooper()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/rc_delegations_config.example.json
+++ b/rc_delegations_config.example.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "Copy this file to rc_delegations_config.json and fill in the real posting key. RC delegation is authorized by the POSTING key of the delegating account (required_posting_auths). rc_delegations_config.json is gitignored.",
+
+  "pay_account": "actifit.pay",
+  "pay_account_posting_key": "PUT_ACTIFIT_PAY_PRIVATE_POSTING_KEY_HERE",
+
+  "active_hive_node": "https://api.hive.blog",
+  "alt_hive_nodes": [
+    "https://api.hive.blog/",
+    "https://hiveapi.actifit.io",
+    "https://api.openhive.network",
+    "https://api.deathwing.me",
+    "https://rpc.mahdiyari.info"
+  ],
+
+  "excludeList": [
+    "vevita", "actifit.s-e", "actifit.h-e", "afitx.s-e", "afitx.h-e",
+    "afit.h-e", "afit.s-e", "actifit-dlux", "actifit.sports", "actifit-he",
+    "hdev.fund", "hdev", "actifit.liquid", "actifit.vsc", "chiuzzu81",
+    "tradelicious", "hivescan.info", "hive.pulse"
+  ],
+
+  "min_total_to_run": 60,
+  "keep_recent": 20,
+  "delay_ms": 3000,
+  "dry_run": true,
+
+  "_order_comment": "'account' = alphabetical by delegatee (RC API default order). 'recent' = reconstruct chronological order from account history so keep_recent keeps the genuinely newest delegations and cancellation drains oldest-first. history_scan_limit caps how many history ops to scan when order=recent.",
+  "order": "recent",
+  "history_scan_limit": 100000
+}

--- a/rc_delegations_script.txt
+++ b/rc_delegations_script.txt
@@ -1,4 +1,4 @@
-const excludeList = ["vevita", "actifit.s-e", "actifit.h-e", "afitx.s-e", "afitx.h-e", "afit.h-e", "afit.s-e", "actifit-dlux", "actifit.sports", "actifit-he", "hdev.fund", "hdev", "actifit.liquid", "actifit.vsc", "chiuzzu81"];
+const excludeList = ["vevita", "actifit.s-e", "actifit.h-e", "afitx.s-e", "afitx.h-e", "afit.h-e", "afit.s-e", "actifit-dlux", "actifit.sports", "actifit-he", "hdev.fund", "hdev", "actifit.liquid", "actifit.vsc", "chiuzzu81", "tradelicious", "chiuzzu81"];
 
 const userKey = '';
 async function cancelDelegation(tgtUser){

--- a/tests/delegations.moveafit.test.js
+++ b/tests/delegations.moveafit.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for the daily AFIT -> Hive-Engine move cleanup / notification changes
+ * and the mongodb driver 5.x migration in delegations.js.
+ *
+ * These exercise the real exported functions against an in-memory mock DB
+ * (injected via __setTestDb). sendNotification is spied so no Firebase / real
+ * notification writes happen.
+ *
+ * Note: the expiry-guard and insufficient-funds branches live inside
+ * moveAFITToSE(), which opens its own Mongo connection, so they can't be driven
+ * with the mock DB here - but both delegate to cancelDailyAFITPowerDown(), which
+ * is covered directly below. Drive moveAFITToSE() itself against a scratch DB in
+ * staging.
+ */
+
+const { ObjectId } = require('mongodb');
+const { createMockDb } = require('./helpers/mock-db');
+const utils = require('../utils');
+const delegations = require('../delegations');
+
+describe('delegations - daily AFIT move cleanup & notifications', () => {
+  let db;
+  let notifySpy;
+
+  const daysAgo = (n) => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - n);
+    return d;
+  };
+
+  beforeEach(() => {
+    db = createMockDb();
+    delegations.__setTestDb(db);
+    notifySpy = jest.spyOn(utils, 'sendNotification').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('deactivateDailyAFITPowerDown (7-day cleanup, now using deleteOne)', () => {
+    test('deletes an entry older than the powerdown window', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'alice', daily_afit_transfer: 100, date: daysAgo(30) };
+      db.collection('powering_down_he').__seed([entry]);
+
+      await delegations.deactivateDailyAFITPowerDown(entry, false);
+
+      expect(db.collection('powering_down_he').deleteOne).toHaveBeenCalledWith({ _id: id });
+      expect(db.collection('powering_down_he').__data()).toHaveLength(0);
+    });
+
+    test('keeps an entry that is still within the window', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'bob', daily_afit_transfer: 100, date: new Date() };
+      db.collection('powering_down_he').__seed([entry]);
+
+      await delegations.deactivateDailyAFITPowerDown(entry, false);
+
+      expect(db.collection('powering_down_he').deleteOne).not.toHaveBeenCalled();
+      expect(db.collection('powering_down_he').__data()).toHaveLength(1);
+    });
+
+    test('does not delete in testMode even when stale', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'carol', daily_afit_transfer: 100, date: daysAgo(30) };
+      db.collection('powering_down_he').__seed([entry]);
+
+      await delegations.deactivateDailyAFITPowerDown(entry, true);
+
+      expect(db.collection('powering_down_he').__data()).toHaveLength(1);
+    });
+  });
+
+  describe('cancelDailyAFITPowerDown (immediate cancel + notify)', () => {
+    test('deletes the entry and notifies the user when a message is given', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'dave', daily_afit_transfer: 100, date: new Date() };
+      db.collection('powering_down_he').__seed([entry]);
+      const msg = 'Your daily move of 100 AFIT to Hive-Engine was cancelled: insufficient funds.';
+
+      await delegations.cancelDailyAFITPowerDown(entry, false, msg);
+
+      expect(db.collection('powering_down_he').__data()).toHaveLength(0);
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect(notifySpy).toHaveBeenCalledWith(
+        db, 'dave', 'actifit', 'afit_move_cancelled', 'afit_move_cancelled', msg, 'https://actifit.io/@dave'
+      );
+    });
+
+    test('deletes silently (no notification) when message is null - expiry path', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'erin', daily_afit_transfer: 100, date: daysAgo(30) };
+      db.collection('powering_down_he').__seed([entry]);
+
+      await delegations.cancelDailyAFITPowerDown(entry, false, null);
+
+      expect(db.collection('powering_down_he').__data()).toHaveLength(0);
+      expect(notifySpy).not.toHaveBeenCalled();
+    });
+
+    test('does nothing in testMode (no delete, no notify)', async () => {
+      const id = new ObjectId();
+      const entry = { _id: id, user: 'frank', daily_afit_transfer: 100, date: new Date() };
+      db.collection('powering_down_he').__seed([entry]);
+
+      await delegations.cancelDailyAFITPowerDown(entry, true, 'msg');
+
+      expect(db.collection('powering_down_he').__data()).toHaveLength(1);
+      expect(notifySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('mongodb driver 5.x migration regressions', () => {
+    test('updateUserCount decrements the off-chain balance via replaceOne', async () => {
+      db.collection('user_tokens').__seed([{ _id: 'grace', user: 'grace', tokens: 500 }]);
+
+      await delegations.updateUserCount({ user: 'grace', daily_afit_transfer: 100 });
+
+      const doc = db.collection('user_tokens').__data()[0];
+      expect(doc.tokens).toBe(400);
+      expect(db.collection('user_tokens').replaceOne).toHaveBeenCalled();
+    });
+
+    test('rollBackTrans removes the inserted token_transaction via deleteOne', async () => {
+      const id = new ObjectId();
+      const moveTrans = { _id: id, user: 'heidi', token_count: -100 };
+      db.collection('token_transactions').__seed([moveTrans]);
+
+      await delegations.rollBackTrans(moveTrans);
+
+      expect(db.collection('token_transactions').deleteOne).toHaveBeenCalledWith({ _id: id });
+      expect(db.collection('token_transactions').__data()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/helpers/mock-db.js
+++ b/tests/helpers/mock-db.js
@@ -59,6 +59,14 @@ function createMockCollection(initialData = []) {
       }
       return Promise.resolve({ modifiedCount: idx !== -1 ? 1 : 0, upsertedCount: opts.upsert && idx === -1 ? 1 : 0 });
     }),
+    deleteOne: jest.fn((query) => {
+      const idx = data.findIndex((doc) => matchQuery(doc, query));
+      if (idx !== -1) {
+        data.splice(idx, 1);
+        return Promise.resolve({ deletedCount: 1 });
+      }
+      return Promise.resolve({ deletedCount: 0 });
+    }),
     deleteMany: jest.fn((query) => {
       const before = data.length;
       data = data.filter((doc) => !matchQuery(doc, query));


### PR DESCRIPTION
Promotes the two commits on develop to master (triggers the two-server deploy pipeline).

## RC delegation cancellation tooling
- `rc_delegations_cancel.js`: runnable replacement for the non-runnable `rc_delegations_script.txt` snapshot. Cancels outgoing RC delegations from `actifit.pay`, loading the private posting key from a separate, gitignored config file. Paginated fetch, exclude list, keep-recent throttle, dry-run by default, optional recency ordering (`order: recent`) reconstructed from account history.
- Config template + README; `rc-cancel` npm script.

## Daily AFIT -> Hive-Engine move fixes
- **Root cause fix:** mongodb driver 5.x removed `.remove()`/`.save()`, but `delegations.js` still called them, so `deactivateDailyAFITPowerDown` threw on every run — stale `powering_down_he` requests were never deleted and power-downs never expired. Migrated to `deleteOne()`/`replaceOne()`.
- `cancelDailyAFITPowerDown()`: immediately cancels a pending request and notifies the user (insufficient AFIT/AFITX funds).
- Expire stale requests (older than `config.afit_powerdown_days || 7`) without moving funds.
- Clamp `min_afitx` to `Math.max(0, ...)` so sub-threshold moves stop storing negatives.
- Made `delegations.js` testable (require.main bootstrap guard, exports, strict-mode octal fix) + added `tests/delegations.moveafit.test.js` (8 tests, passing) and `deleteOne` to the mock-db helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)