### PR TITLE
ci: restart all pm2 processes on deploy (not just 'app')

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,10 @@ jobs:
             git checkout -- package-lock.json || true
             git pull origin master
             npm install --production
-            pm2 restart app
+            # restart every pm2-managed process this bot runs, not just the web
+            # 'app' - the daily AFIT move / rewards worker (api-delegations, see
+            # delegationsconfig.js) runs as a separate process and must reload too.
+            # 'restart all' only touches processes already running on that host,
+            # so it won't start a duplicate delegation worker on servers that
+            # don't run one.
+            pm2 restart all


### PR DESCRIPTION
## Problem
The deploy pipeline runs `pm2 restart app`, which only restarts the web process. The daily AFIT->H-E move / rewards logic runs in a **separate** pm2 worker (`api-delegations`, see `delegationsconfig.js`). After a `git pull`, that worker keeps running the old `delegations.js` in memory — so `delegations.js` fixes silently don't take effect until someone restarts it manually. This just bit the move-cleanup/notify fix in #32.

## Fix
Change `pm2 restart app` -> `pm2 restart all`.

`pm2 restart all` only restarts processes **already running** on each host, so:
- the `api-delegations` worker reloads wherever it runs, and
- there's no risk of starting a duplicate delegation worker on a host that doesn't run one (restart != start).

## Note
Activates on the next `develop -> master` promotion (the deploy workflow triggers on push to `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)