### PR TITLE
Deploy: pm2 restart all (activates delegations worker reload)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,4 +26,10 @@ jobs:
             git checkout -- package-lock.json || true
             git pull origin master
             npm install --production
-            pm2 restart app
+            # restart every pm2-managed process this bot runs, not just the web
+            # 'app' - the daily AFIT move / rewards worker (api-delegations, see
+            # delegationsconfig.js) runs as a separate process and must reload too.
+            # 'restart all' only touches processes already running on that host,
+            # so it won't start a duplicate delegation worker on servers that
+            # don't run one.
+            pm2 restart all


### PR DESCRIPTION
Promotes the CI fix from #33 to master.

Merging this triggers the deploy pipeline, which now runs `pm2 restart all` (from the updated deploy.yml in this promotion). That:
- activates the `pm2 restart all` change for all future deploys, **and**
- restarts the `api-delegations` worker on the servers, finally loading the `delegations.js` daily-move fixes shipped in #32 (the earlier deploy only ran `pm2 restart app`, leaving that worker on old code).

No new app code beyond #32 + #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)