### PR TITLE
Hotfix: pm2 crash-loop (require.main === module is always false under pm2)

### DIFF
--- a/delegations.js
+++ b/delegations.js
@@ -88,10 +88,16 @@ if (process.env.BOT_THREAD == 'MAIN'){
 	
 	
 }else */
-// Only auto-run the scheduler / reward pipeline when executed directly
-// (node delegations.js / pm2). When required by a test, skip bootstrap so the
-// exported functions can be exercised in isolation.
-if (require.main === module) {
+// Auto-run the scheduler / reward pipeline everywhere EXCEPT under test, where we
+// only want to require() the module and exercise its exported functions.
+//
+// Do NOT use `require.main === module` here: pm2's fork mode does not run the script
+// directly, it require()s it from its own wrapper (ProcessContainerFork), so
+// require.main is pm2's wrapper and the check is always false. That silently skipped
+// the entire bootstrap - no schedulers, no timers - so the event loop emptied, the
+// process exited, and pm2 crash-looped it (taking the box down with it).
+// Jest sets NODE_ENV=test automatically; production/pm2 does not.
+if (process.env.NODE_ENV !== 'test') {
 if (process.env.BOT_THREAD == 'MAIN'){
 
 	console.log('>>>>>>>>>MAIN DELEGATION THREAD<<<<<<<<<<<')


### PR DESCRIPTION
## Production impact
Users could not log in (web + mobile). `api2.actifit.io` was returning intermittent **502s** (~30% of requests, in periodic bursts) — the CORS errors in the browser console were a symptom, not the cause (a 502 response carries no `Access-Control-Allow-Origin` header).

## Root cause — mine
The bootstrap guard I added to `delegations.js` used `require.main === module`. **pm2's fork mode does not run the script directly** — it `require()`s it from its own wrapper (`ProcessContainerFork`). So `require.main` is pm2's wrapper, and the check is **always false** in production.

Once `pm2 restart all` (added in #33) reloaded `api-delegations` onto this code:
- the entire bootstrap was skipped → no schedulers, no timers
- the event loop emptied → **the process exited immediately**
- pm2 restarted it, over and over → **crash loop**, hammering the box
- the API process started returning intermittent **502s** → login broke
- and the **daily AFIT→H-E move / rewards worker never ran at all**

## Fix
Guard on `NODE_ENV` instead. Jest sets `NODE_ENV=test` automatically; production/pm2 does not — so the bootstrap runs everywhere except under test.

```js
if (process.env.NODE_ENV !== 'test') { ...bootstrap... }
```

Test suite still passes (8/8), with the bootstrap correctly skipped under jest.

## Deploy
Merge → promote develop to master (fires the deploy pipeline to both servers). Immediate mitigation meanwhile: `pm2 stop api-delegations` on both servers stops the crash loop and restores login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)