### PR TITLE
Deploy hotfix: pm2 crash-loop breaking user login (502s)

### DIFF
--- a/delegations.js
+++ b/delegations.js
@@ -88,10 +88,16 @@ if (process.env.BOT_THREAD == 'MAIN'){
 	
 	
 }else */
-// Only auto-run the scheduler / reward pipeline when executed directly
-// (node delegations.js / pm2). When required by a test, skip bootstrap so the
-// exported functions can be exercised in isolation.
-if (require.main === module) {
+// Auto-run the scheduler / reward pipeline everywhere EXCEPT under test, where we
+// only want to require() the module and exercise its exported functions.
+//
+// Do NOT use `require.main === module` here: pm2's fork mode does not run the script
+// directly, it require()s it from its own wrapper (ProcessContainerFork), so
+// require.main is pm2's wrapper and the check is always false. That silently skipped
+// the entire bootstrap - no schedulers, no timers - so the event loop emptied, the
+// process exited, and pm2 crash-looped it (taking the box down with it).
+// Jest sets NODE_ENV=test automatically; production/pm2 does not.
+if (process.env.NODE_ENV !== 'test') {
 if (process.env.BOT_THREAD == 'MAIN'){
 
 	console.log('>>>>>>>>>MAIN DELEGATION THREAD<<<<<<<<<<<')


### PR DESCRIPTION
Promotes #35 to master, firing the deploy pipeline to both servers.

## Fixes a live outage
Users could not log in (web + mobile). `api2.actifit.io` was returning intermittent **502s** (~30% of requests, in ~28s bursts).

**Root cause:** the bootstrap guard in `delegations.js` used `require.main === module`, which is **always false under pm2** (fork mode `require()`s the script from its own wrapper rather than running it directly). Once `pm2 restart all` reloaded `api-delegations` onto that code, the bootstrap was skipped → event loop emptied → process exited → pm2 crash-looped it, hammering the box and 502ing the API. The CORS errors in the browser console were a symptom (a 502 carries no `Access-Control-Allow-Origin` header), not the cause.

Also meant the **daily AFIT→H-E move / rewards worker never ran** since that deploy.

**Fix:** guard on `process.env.NODE_ENV !== 'test'` instead. Jest sets `NODE_ENV=test`; pm2/production does not. Tests pass 8/8 with the bootstrap correctly skipped under test.

## After merge
The pipeline runs `pm2 restart all` on both servers, which will bring `api-delegations` back up correctly. If you ran `pm2 stop api-delegations` as mitigation, confirm it comes back online (`pm2 list`) — a stopped process is not restarted by `pm2 restart all`, so it may need `pm2 start api-delegations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)