### PR TITLE
Fix web3 v4 fromWei calls missing the required unit arg

### DIFF
--- a/app.js
+++ b/app.js
@@ -1376,7 +1376,7 @@ const grabUserTokensFunc = async function (username, fullBal){
 				//fetch wallet balance		
 				let result = await afitContract.methods.balanceOf(wallet_entry.wallet).call();
 				
-				let format = web3.utils.fromWei(result); // 29803630.997051883414242659
+				let format = web3.utils.fromWei(result.toString(), 'ether'); // Web3 v4: unit is required, BigInt needs toString()
 				const afitBSC = parseFloat(format);
 				//console.log(format);
 				user.tokens = parseFloat(user.tokens) + afitBSC;
@@ -1601,7 +1601,7 @@ app.get('/circulatingSupplyAFIT', async function (req,res){
 		//grab balances of well-known actifit wallets, and deduct balance from total supply
 		for (let i=0;i<config.actifitSpWallets.length;i++){
 			let result = await afitContract.methods.balanceOf(config.actifitSpWallets[i]).call(); // 29803630997051883414242659
-			let format = web3.utils.fromWei(result); // 29803630.997051883414242659
+			let format = web3.utils.fromWei(result.toString(), 'ether'); // Web3 v4: unit is required, BigInt needs toString()
 			const afitBSC = parseFloat(format);
 			cirSupply -= afitBSC;
 		}
@@ -6384,16 +6384,16 @@ const calcRank = async function (req, res){
 		console.log(wallet_entry.wallet);
 		//fetch wallet balance		
 		let result = await afitContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitBSC = parseFloat(format); console.log(format); }
 
 		result = await afitxContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitxBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitxBSC = parseFloat(format); console.log(format); }
 
 		result = await afitBNBLPContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitBNBLPBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitBNBLPBSC = parseFloat(format); console.log(format); }
 
 		result = await afitxBNBLPContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitxBNBLPBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitxBNBLPBSC = parseFloat(format); console.log(format); }
 	}
 	}catch(err){
 		console.log(err);


### PR DESCRIPTION
web3 was upgraded to **v4.16.0**, where `fromWei(value, unit)` requires the unit (v1 defaulted it to `'ether'`). Two call sites were migrated (with a *"Web3 v4: unit is required"* note) but **six were missed**, so each threw:

```
InvalidIntegerError: Invalid value given "undefined". not a valid unit.
```

The four in `calcRank` sit inside a `try/catch`, so they didn't crash the process — they failed **before the assignment**, which is worse: every user's BSC balances (`afit_BSC`, `afitx_BSC`, `afit_BNB_LP_BSC`, `afitx_BNB_LP_BSC`) came back as **0**, silently excluding BSC holdings from user rank.

Fix: pass `'ether'` explicitly and `.toString()` the BigInt result, matching the two already-migrated call sites.

Note: this is **not** the cause of the api2 502s / login outage — those errors are caught. Shipping this separately as a real correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)