### PR TITLE
Deploy: web3 v4 fromWei unit fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -1376,7 +1376,7 @@ const grabUserTokensFunc = async function (username, fullBal){
 				//fetch wallet balance		
 				let result = await afitContract.methods.balanceOf(wallet_entry.wallet).call();
 				
-				let format = web3.utils.fromWei(result); // 29803630.997051883414242659
+				let format = web3.utils.fromWei(result.toString(), 'ether'); // Web3 v4: unit is required, BigInt needs toString()
 				const afitBSC = parseFloat(format);
 				//console.log(format);
 				user.tokens = parseFloat(user.tokens) + afitBSC;
@@ -1601,7 +1601,7 @@ app.get('/circulatingSupplyAFIT', async function (req,res){
 		//grab balances of well-known actifit wallets, and deduct balance from total supply
 		for (let i=0;i<config.actifitSpWallets.length;i++){
 			let result = await afitContract.methods.balanceOf(config.actifitSpWallets[i]).call(); // 29803630997051883414242659
-			let format = web3.utils.fromWei(result); // 29803630.997051883414242659
+			let format = web3.utils.fromWei(result.toString(), 'ether'); // Web3 v4: unit is required, BigInt needs toString()
 			const afitBSC = parseFloat(format);
 			cirSupply -= afitBSC;
 		}
@@ -6384,16 +6384,16 @@ const calcRank = async function (req, res){
 		console.log(wallet_entry.wallet);
 		//fetch wallet balance		
 		let result = await afitContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitBSC = parseFloat(format); console.log(format); }
 
 		result = await afitxContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitxBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitxBSC = parseFloat(format); console.log(format); }
 
 		result = await afitBNBLPContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitBNBLPBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitBNBLPBSC = parseFloat(format); console.log(format); }
 
 		result = await afitxBNBLPContract.methods.balanceOf(wallet_entry.wallet).call();
-		if (result != null) { let format = web3.utils.fromWei(result); afitxBNBLPBSC = parseFloat(format); console.log(format); }
+		if (result != null) { let format = web3.utils.fromWei(result.toString(), 'ether'); afitxBNBLPBSC = parseFloat(format); console.log(format); }
 	}
 	}catch(err){
 		console.log(err);


### PR DESCRIPTION
Promotes #37 to master (fires the deploy pipeline to both servers).

**Fix:** web3 v4.16.0 requires the unit arg in `fromWei(value, unit)`. Six call sites still used v1 syntax and threw `InvalidIntegerError: not a valid unit`. The four in `calcRank` are inside a try/catch, so they didn't crash — they failed *before* assignment, meaning **every user's BSC balances were counted as 0** and BSC holdings were excluded from user rank.

**Note:** this is NOT the fix for the api2 502 / login outage — those errors are caught and don't crash the process. That root cause is still under investigation (need `pm2 list` to tell crash-loop from unresponsive-upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)