### PR TITLE
Hotfix: guard null account data - /votingStatus crash is killing the API (login outage)

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -109,10 +109,23 @@ var HOURS = 60 * 60;
  async function getAccountData(account_name, bchain){
 	let account = {};
 	if (!bchain || bchain == ''){
-		let account_res = await hive.api.getAccountsAsync([account_name]); 
-		account['HIVE']=account_res[0];
-		account_res = await blurt.api.getAccountsAsync([account_name]); 
-		account['BLURT']=account_res[0];
+		// A node hiccup can return null/empty here. Indexing [0] blind threw
+		// "Cannot read properties of null (reading '0')" as an UNHANDLED rejection,
+		// which kills the API process (node 20). Guard it, like the else-branch does.
+		try{
+			let account_res = await hive.api.getAccountsAsync([account_name]);
+			account['HIVE'] = (Array.isArray(account_res) && account_res.length) ? account_res[0] : null;
+		}catch(err){
+			console.log('getAccountData HIVE failed: ' + (err && err.message ? err.message : err));
+			account['HIVE'] = null;
+		}
+		try{
+			let account_res = await blurt.api.getAccountsAsync([account_name]);
+			account['BLURT'] = (Array.isArray(account_res) && account_res.length) ? account_res[0] : null;
+		}catch(err){
+			console.log('getAccountData BLURT failed: ' + (err && err.message ? err.message : err));
+			account['BLURT'] = null;
+		}
 	}else{
 		let chainLnk = await setProperNode(bchain);
 		//attempt to load account data
@@ -291,6 +304,13 @@ var HOURS = 60 * 60;
  
 	//fixed implementation of proper voting power calculation
 	function getVotingPower(account) {
+		// Account data is missing whenever the node call above failed. Dereferencing it
+		// blind threw "Cannot read properties of undefined (reading 'vesting_shares')" as
+		// an UNHANDLED rejection, killing the API process. Return 0 instead.
+		if (!account || !account.vesting_shares || !account.voting_manabar) {
+			console.log('getVotingPower: no account data (node call likely failed) - returning 0');
+			return 0;
+		}
 		const totalShares = parseFloat(account.vesting_shares) + parseFloat(account.received_vesting_shares) - parseFloat(account.delegated_vesting_shares) - parseFloat(account.vesting_withdraw_rate);
 
             const elapsed = Math.floor(Date.now() / 1000) - account.voting_manabar.last_update_time;


### PR DESCRIPTION
## Live outage
Users cannot log in. Every `api2.actifit.io` endpoint intermittently returns **502**.

## Root cause
`/votingStatus` (app.js:1672) calls `utils.getVotingPower(account[bchain])` at app.js:1687. When a Hive/Blurt node hiccups and returns null, that dereferences `account.vesting_shares` on `undefined` and throws — as an **unhandled rejection, which is fatal on node 20**. The API process dies, pm2 restarts it, and every request in the gap 502s. The frontend polls `/votingStatus` constantly, so this fires repeatedly.

```
TypeError: Cannot read properties of undefined (reading 'vesting_shares')
    at Object.getVotingPower (utils.js:294)
    at app.js:1687   <-- inside /votingStatus
```

## Fix
- **`getVotingPower()`** — return `0` when account data is missing instead of dereferencing it blind.
- **`getAccountData()`** — the no-bchain (HIVE/BLURT) branch indexed `account_res[0]` with no try/catch (its else-branch already had one), throwing `Cannot read properties of null (reading '0')` on the same node hiccups. Now guarded, defaulting to `null`.

Neither can take the process down anymore.

Tests: 125/125 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)